### PR TITLE
Release main/Smdn.Text.Ondulish.Dictionaries-4.0.0-preview1

### DIFF
--- a/doc/api-list/Smdn.Text.Ondulish.Dictionaries/Smdn.Text.Ondulish.Dictionaries-net6.0.apilist.cs
+++ b/doc/api-list/Smdn.Text.Ondulish.Dictionaries/Smdn.Text.Ondulish.Dictionaries-net6.0.apilist.cs
@@ -1,0 +1,19 @@
+// Smdn.Text.Ondulish.Dictionaries.dll (Smdn.Text.Ondulish.Dictionaries-4.0.0-preview1)
+//   Name: Smdn.Text.Ondulish.Dictionaries
+//   AssemblyVersion: 4.0.0.0
+//   InformationalVersion: 4.0.0-preview1+e47f0cd7079b79c34ed00e252d68a337f739d938
+//   TargetFramework: .NETCoreApp,Version=v6.0
+//   Configuration: Release
+//   Embedded resources:
+//     Smdn.Text.Ondulish.Dictionaries.phrases (4,549 bytes, Embedded, ContainedInManifestFile)
+//     Smdn.Text.Ondulish.Dictionaries.words (1,751 bytes, Embedded, ContainedInManifestFile)
+#nullable enable annotations
+
+using System.IO;
+
+namespace Smdn.Text.Ondulish {
+  public static class OndulishDictionaries {
+    public static Stream OpenPhraseDictionaryStream() {}
+    public static Stream OpenWordDictionaryStream() {}
+  }
+}

--- a/doc/api-list/Smdn.Text.Ondulish.Dictionaries/Smdn.Text.Ondulish.Dictionaries-netstandard2.0.apilist.cs
+++ b/doc/api-list/Smdn.Text.Ondulish.Dictionaries/Smdn.Text.Ondulish.Dictionaries-netstandard2.0.apilist.cs
@@ -1,0 +1,19 @@
+// Smdn.Text.Ondulish.Dictionaries.dll (Smdn.Text.Ondulish.Dictionaries-4.0.0-preview1)
+//   Name: Smdn.Text.Ondulish.Dictionaries
+//   AssemblyVersion: 4.0.0.0
+//   InformationalVersion: 4.0.0-preview1+e47f0cd7079b79c34ed00e252d68a337f739d938
+//   TargetFramework: .NETStandard,Version=v2.0
+//   Configuration: Release
+//   Embedded resources:
+//     Smdn.Text.Ondulish.Dictionaries.phrases (4,549 bytes, Embedded, ContainedInManifestFile)
+//     Smdn.Text.Ondulish.Dictionaries.words (1,751 bytes, Embedded, ContainedInManifestFile)
+#nullable enable annotations
+
+using System.IO;
+
+namespace Smdn.Text.Ondulish {
+  public static class OndulishDictionaries {
+    public static Stream OpenPhraseDictionaryStream() {}
+    public static Stream OpenWordDictionaryStream() {}
+  }
+}


### PR DESCRIPTION
Automatically generated by workflow [Generate release target #1](https://github.com/smdn/Smdn.Text.Ondulish/actions/runs/3816956037).

# Release target
- package_target_tag: `new-release/main/Smdn.Text.Ondulish.Dictionaries-4.0.0-preview1`
- package_prevver_ref: `d1c6880233e881135e0d5c9116b0e6e5b749bb61`
- package_prevver_tag: -
- package_id: `Smdn.Text.Ondulish.Dictionaries`
- package_id_with_version: `Smdn.Text.Ondulish.Dictionaries-4.0.0-preview1`
- package_version: `4.0.0-preview1`
- package_branch: `main`
- release_working_branch: `releases/Smdn.Text.Ondulish.Dictionaries-4.0.0-preview1-1672578382`
- release_tag: `releases/Smdn.Text.Ondulish.Dictionaries-4.0.0-preview1`
- release_draft: `false` ❗Change this value to `true` to create release note as draft.
- release_note_url: [`https://gist.github.com/b44ff16999cfcd3cdb7e3460df31dcce`](https://gist.github.com/b44ff16999cfcd3cdb7e3460df31dcce)
- artifact_name_nupkg: `Smdn.Text.Ondulish.Dictionaries.4.0.0-preview1.nupkg` ❗Remove this line or change this value to empty to prevent publishing packages.

# .nuspec
```nuspec
<?xml version="1.0" encoding="utf-8"?>
<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
  <metadata>
    <id>Smdn.Text.Ondulish.Dictionaries</id>
    <version>4.0.0-preview1</version>
    <title>Smdn.Text.Ondulish.Dictionaries</title>
    <authors>smdn</authors>
    <license type="expression">MIT</license>
    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
    <icon>Smdn.Text.Ondulish.Dictionaries.png</icon>
    <readme>README.md</readme>
    <projectUrl>https://github.com/smdn/Smdn.Text.Ondulish</projectUrl>
    <description>An Ondulish dictionary assembly for Smdn.Text.Ondulish.</description>
    <copyright>Copyright © 2022 smdn</copyright>
    <tags>smdn.jp joke funny text-converter translator</tags>
    <repository type="git" url="https://github.com/smdn/Smdn.Text.Ondulish" branch="main" commit="e47f0cd7079b79c34ed00e252d68a337f739d938" />
    <dependencies>
      <group targetFramework="net6.0" />
      <group targetFramework=".NETStandard2.0" />
    </dependencies>
  </metadata>
  <files>
    <file src="/home/runner/work/Smdn.Text.Ondulish/Smdn.Text.Ondulish/src/Smdn.Text.Ondulish.Dictionaries/bin/Release/net6.0/Smdn.Text.Ondulish.Dictionaries.dll" target="lib/net6.0/Smdn.Text.Ondulish.Dictionaries.dll" />
    <file src="/home/runner/work/Smdn.Text.Ondulish/Smdn.Text.Ondulish/src/Smdn.Text.Ondulish.Dictionaries/bin/Release/netstandard2.0/Smdn.Text.Ondulish.Dictionaries.dll" target="lib/netstandard2.0/Smdn.Text.Ondulish.Dictionaries.dll" />
    <file src="/home/runner/work/Smdn.Text.Ondulish/Smdn.Text.Ondulish/.nuget/packages/smdn.msbuild.projectassets.common/1.1.3/project/images/package-icon.png" target="Smdn.Text.Ondulish.Dictionaries.png" />
    <file src="/home/runner/work/Smdn.Text.Ondulish/Smdn.Text.Ondulish/src/Smdn.Text.Ondulish.Dictionaries/bin/Release/README.md" target="README.md" />
  </files>
</package>
```

